### PR TITLE
fix: Update file-collections to fix product image upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -366,12 +366,12 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
@@ -1009,15 +1009,6 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
-    "@babel/runtime-corejs2": {
-      "version": "7.10.3",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/@babel/runtime-corejs2/-/runtime-corejs2-7.10.3.tgz",
-      "integrity": "sha1-gbyZqWv8tts/Dc9z/cV3zFVNNBs=",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/runtime-corejs3": {
       "version": "7.10.3",
       "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/@babel/runtime-corejs3/-/runtime-corejs3-7.10.3.tgz",
@@ -1128,13 +1119,13 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
@@ -1213,13 +1204,13 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
@@ -1302,13 +1293,13 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
@@ -1489,7 +1480,7 @@
     },
     "@marionebl/sander": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/@marionebl/sander/-/sander-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
       "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
       "dev": true,
       "requires": {
@@ -1747,9 +1738,9 @@
       "dev": true
     },
     "@reactioncommerce/file-collections": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections/-/file-collections-0.8.0.tgz",
-      "integrity": "sha512-9jVfpWUnSZUeR8QD/aofeheKOPaJNAfyOcWb8NmkqKMJ4msUdhz59b8uwCr0j/zZ74vC/bAY1rYc3gsdNg28kg==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections/-/file-collections-0.9.3.tgz",
+      "integrity": "sha512-8HLEjvlhtgpOAQYQeHA6UGYJfbYoSuUtQAyo0E0DUUpgeViXiWgQ+T4DIK3NbUinlvA4Ny8FDtZCNEg5eHCfMw==",
       "requires": {
         "@babel/runtime-corejs2": "^7.10.5",
         "content-disposition": "^0.5.3",
@@ -1757,83 +1748,59 @@
         "extend": "~3.0.2",
         "path-parser": "^6.1.0",
         "query-string": "^6.13.1",
-        "tus-js-client": "^2.1.1",
+        "tus-js-client": "^1.5.1",
         "tus-node-server": "~0.3.2"
       },
       "dependencies": {
         "@babel/runtime-corejs2": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.11.2.tgz",
-          "integrity": "sha512-AC/ciV28adSSpEkBglONBWq4/Lvm6GAZuxIoyVtsnUpZMl0bxLtoChEnYAkP+47KyOCayZanojtflUEUJtR/6Q==",
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
+          "integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
           "requires": {
             "core-js": "^2.6.5",
             "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
           }
         }
       }
     },
     "@reactioncommerce/file-collections-sa-base": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections-sa-base/-/file-collections-sa-base-0.2.0.tgz",
-      "integrity": "sha512-uWV+kNdhxASKYZCG2gFy+BvaKRClhXu7jvp0fkVL9khwRmdZI1CBeX6fgYDYNX6OfO6UfoJoszBRkkyYE/LAbQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections-sa-base/-/file-collections-sa-base-0.2.1.tgz",
+      "integrity": "sha512-GK/7U5LVbmGGg4blrW0U9kEEWx1GrGlPLWr2i92xkGZ1vnDXOaDTgBiuilAgpQlPKhfc1oL69n7Tob+21J8Q9A==",
       "requires": {
         "@babel/runtime-corejs2": "^7.10.5",
         "debug": "^4.1.1"
       },
       "dependencies": {
         "@babel/runtime-corejs2": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.11.2.tgz",
-          "integrity": "sha512-AC/ciV28adSSpEkBglONBWq4/Lvm6GAZuxIoyVtsnUpZMl0bxLtoChEnYAkP+47KyOCayZanojtflUEUJtR/6Q==",
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
+          "integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
           "requires": {
             "core-js": "^2.6.5",
             "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
           }
         }
       }
     },
     "@reactioncommerce/file-collections-sa-gridfs": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections-sa-gridfs/-/file-collections-sa-gridfs-0.1.3.tgz",
-      "integrity": "sha512-xzrtoIpEB7Ry+YzBTZPZq0cR+9fNrfquU3q/iHNNSQJBrOaAqo0+MXFHk+xAVSSwMC6llyw8imRHx5Kmu2Ol+w==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/file-collections-sa-gridfs/-/file-collections-sa-gridfs-0.1.4.tgz",
+      "integrity": "sha512-TmT7cI1guhnc2SCsR1ECQiAqysge5jeIlC23uXIF4mB5U18GUcQ0WlOOFyU0a6qCHpczl7G/6GwuYD4KATNkVQ==",
       "requires": {
         "@babel/runtime-corejs2": "^7.10.5",
-        "@reactioncommerce/file-collections-sa-base": "^0.2.0",
+        "@reactioncommerce/file-collections-sa-base": "^0.2.1",
         "debug": "^4.1.1",
         "gridfs-stream": "^1.1.1"
       },
       "dependencies": {
         "@babel/runtime-corejs2": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.11.2.tgz",
-          "integrity": "sha512-AC/ciV28adSSpEkBglONBWq4/Lvm6GAZuxIoyVtsnUpZMl0bxLtoChEnYAkP+47KyOCayZanojtflUEUJtR/6Q==",
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
+          "integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
           "requires": {
             "core-js": "^2.6.5",
             "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
           }
         }
       }
@@ -2079,7 +2046,7 @@
     },
     "@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/@types/json5/-/json5-0.0.29.tgz",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
@@ -2301,12 +2268,12 @@
     },
     "ansicolors": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ansicolors/-/ansicolors-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
       "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
     },
     "ansistyles": {
       "version": "0.1.3",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ansistyles/-/ansistyles-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
       "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
     },
     "aproba": {
@@ -2334,7 +2301,7 @@
     },
     "argv-formatter": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/argv-formatter/-/argv-formatter-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
       "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=",
       "dev": true
     },
@@ -2350,13 +2317,13 @@
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-ify": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/array-ify/-/array-ify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
       "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
       "dev": true
     },
@@ -2394,7 +2361,7 @@
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1": {
@@ -2407,12 +2374,12 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "ast-types-flow": {
       "version": "0.0.7",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
@@ -2432,7 +2399,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
@@ -2442,9 +2409,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.736.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.736.0.tgz",
-      "integrity": "sha512-rDrLgxkiFX+9EksDx4Lc6qLA07Pf0xfqqXnM3CpLBL81aVOdmmXAiBPtz/KSgbcrR5Mxz38ah8x5RZ17stJQjw==",
+      "version": "2.793.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.793.0.tgz",
+      "integrity": "sha512-zBrDkYAUadS59+GVhhVT8f7medKv2FO/3sX3QDfgHt0ySUYi4umBwp3fXjoJU2oRG70IZ74Wclx4T4tynA+Gjg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -2466,7 +2433,7 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
@@ -2520,7 +2487,7 @@
     },
     "babel-polyfill": {
       "version": "6.26.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
@@ -2531,7 +2498,7 @@
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.10.5",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
           "dev": true
         }
@@ -2539,7 +2506,7 @@
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
@@ -2557,7 +2524,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
@@ -2567,7 +2534,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -2678,7 +2645,7 @@
     },
     "bunyan-format": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/bunyan-format/-/bunyan-format-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/bunyan-format/-/bunyan-format-0.2.1.tgz",
       "integrity": "sha1-pLOw2ABwqGUnlBcmnj8A/wL7y0c=",
       "requires": {
         "ansicolors": "~0.2.1",
@@ -2688,7 +2655,7 @@
     },
     "caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
@@ -2697,7 +2664,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -2705,7 +2672,7 @@
     },
     "caller-path": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/caller-path/-/caller-path-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
@@ -2752,7 +2719,7 @@
     },
     "cardinal": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/cardinal/-/cardinal-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
       "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
       "dev": true,
       "requires": {
@@ -2762,7 +2729,7 @@
       "dependencies": {
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ansicolors/-/ansicolors-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
           "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "dev": true
         }
@@ -2770,7 +2737,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
@@ -2815,7 +2782,7 @@
     },
     "cli-table": {
       "version": "0.3.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/cli-table/-/cli-table-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
       "dev": true,
       "requires": {
@@ -2896,7 +2863,7 @@
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/colors/-/colors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
@@ -2929,7 +2896,7 @@
       "dependencies": {
         "dot-prop": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/dot-prop/-/dot-prop-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
           "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
           "dev": true,
           "requires": {
@@ -2954,7 +2921,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
@@ -2995,7 +2962,7 @@
     },
     "contains-path": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/contains-path/-/contains-path-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
@@ -3214,7 +3181,7 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
@@ -3231,7 +3198,7 @@
       "dependencies": {
         "import-fresh": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/import-fresh/-/import-fresh-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
           "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
           "dev": true,
           "requires": {
@@ -3241,7 +3208,7 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -3251,7 +3218,7 @@
         },
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/resolve-from/-/resolve-from-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -3298,7 +3265,7 @@
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
@@ -3324,7 +3291,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -3337,21 +3304,21 @@
       "dev": true
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
@@ -3361,7 +3328,7 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
         }
@@ -3387,7 +3354,7 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
@@ -3410,7 +3377,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
@@ -3484,7 +3451,7 @@
     },
     "duplexer2": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/duplexer2/-/duplexer2-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
@@ -3504,7 +3471,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
@@ -3592,7 +3559,7 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "dotenv": {
@@ -3602,7 +3569,7 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
@@ -3631,7 +3598,7 @@
       "dependencies": {
         "is-arrayish": {
           "version": "0.2.1",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
           "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         }
@@ -3690,7 +3657,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
@@ -3775,7 +3742,7 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
@@ -3799,7 +3766,7 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
@@ -3856,7 +3823,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -3883,7 +3850,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -3939,7 +3906,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -3949,7 +3916,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -3958,7 +3925,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -3970,7 +3937,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
@@ -3980,7 +3947,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
@@ -3995,7 +3962,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
@@ -4004,13 +3971,13 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/parse-json/-/parse-json-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
@@ -4019,13 +3986,13 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-type": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/path-type/-/path-type-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
@@ -4034,13 +4001,13 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/read-pkg/-/read-pkg-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
@@ -4051,7 +4018,7 @@
         },
         "read-pkg-up": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
@@ -4362,12 +4329,12 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "faker": {
       "version": "4.1.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/faker/-/faker-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
       "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
       "dev": true
     },
@@ -4397,7 +4364,7 @@
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
@@ -4526,7 +4493,7 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
@@ -4541,7 +4508,7 @@
     },
     "from2": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/from2/-/from2-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
@@ -4568,7 +4535,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -4580,7 +4547,7 @@
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
@@ -4705,7 +4672,7 @@
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -4713,7 +4680,7 @@
     },
     "git-log-parser": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/git-log-parser/-/git-log-parser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
       "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
       "dev": true,
       "requires": {
@@ -4727,7 +4694,7 @@
       "dependencies": {
         "split2": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/split2/-/split2-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
           "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
           "dev": true,
           "requires": {
@@ -4800,7 +4767,7 @@
     },
     "glob": {
       "version": "6.0.4",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/glob/-/glob-6.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
       "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
       "optional": true,
       "requires": {
@@ -4822,7 +4789,7 @@
     },
     "global-dirs": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/global-dirs/-/global-dirs-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
@@ -4952,7 +4919,7 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
@@ -4996,12 +4963,9 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hash-stream-validation": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.3.tgz",
-      "integrity": "sha512-OEohGLoUOh+bwsIpHpdvhIXFyRGjeLqJbT8Yc5QTZPbRM7LKywagTQxnX/6mghLDOrD9YGz88hy5mLN2eKflYQ==",
-      "requires": {
-        "through2": "^2.0.0"
-      }
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz",
+      "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ=="
     },
     "hook-std": {
       "version": "2.0.0",
@@ -5048,7 +5012,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -5063,6 +5027,16 @@
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "human-signals": {
@@ -5168,7 +5142,7 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
@@ -5179,7 +5153,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
@@ -5270,9 +5244,9 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
     "is-callable": {
       "version": "1.2.0",
@@ -5296,13 +5270,13 @@
     },
     "is-directory": {
       "version": "0.3.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/is-directory/-/is-directory-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
@@ -5327,12 +5301,12 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
@@ -5381,7 +5355,7 @@
     },
     "is-text-path": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/is-text-path/-/is-text-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
@@ -5390,17 +5364,17 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -5412,7 +5386,7 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "issue-parser": {
@@ -5430,7 +5404,7 @@
       "dependencies": {
         "lodash.uniqby": {
           "version": "4.7.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
           "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
           "dev": true
         }
@@ -5536,7 +5510,7 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsesc": {
@@ -5553,7 +5527,7 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
@@ -5563,13 +5537,13 @@
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
@@ -5593,13 +5567,13 @@
     },
     "jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/jsonparse/-/jsonparse-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -5651,7 +5625,7 @@
     },
     "language-tags": {
       "version": "1.0.5",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/language-tags/-/language-tags-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
       "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
       "dev": true,
       "requires": {
@@ -5675,7 +5649,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -5685,13 +5659,13 @@
     },
     "lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
     "load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
@@ -5703,7 +5677,7 @@
       "dependencies": {
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -5713,7 +5687,7 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -5761,7 +5735,7 @@
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "lodash._root": {
@@ -5779,42 +5753,42 @@
     },
     "lodash.capitalize": {
       "version": "4.2.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
       "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
       "dev": true
     },
     "lodash.escaperegexp": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
       "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.ismatch": {
       "version": "4.4.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
       "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.set": {
       "version": "4.3.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/lodash.set/-/lodash.set-4.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
@@ -5842,7 +5816,7 @@
     },
     "lodash.toarray": {
       "version": "4.4.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
       "dev": true
     },
@@ -5871,7 +5845,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -5959,13 +5933,13 @@
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "camelcase-keys": {
           "version": "4.2.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
@@ -5976,7 +5950,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -5985,13 +5959,13 @@
         },
         "indent-string": {
           "version": "3.2.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/indent-string/-/indent-string-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
           "dev": true
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
@@ -6001,7 +5975,7 @@
         },
         "map-obj": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/map-obj/-/map-obj-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
           "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
           "dev": true
         },
@@ -6026,7 +6000,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
@@ -6035,25 +6009,25 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "quick-lru": {
           "version": "1.1.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/quick-lru/-/quick-lru-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
           "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
           "dev": true
         },
         "read-pkg": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/read-pkg/-/read-pkg-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
@@ -6064,7 +6038,7 @@
         },
         "read-pkg-up": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
@@ -6074,7 +6048,7 @@
         },
         "redent": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/redent/-/redent-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
@@ -6084,13 +6058,13 @@
         },
         "strip-indent": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/strip-indent/-/strip-indent-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
           "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
           "dev": true
         },
         "trim-newlines": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/trim-newlines/-/trim-newlines-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
           "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
           "dev": true
         },
@@ -6245,7 +6219,7 @@
     },
     "mv": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/mv/-/mv-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
       "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
       "optional": true,
       "requires": {
@@ -6267,13 +6241,13 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "optional": true
     },
@@ -6285,7 +6259,7 @@
     },
     "nerf-dart": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/nerf-dart/-/nerf-dart-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
       "dev": true
     },
@@ -9954,7 +9928,7 @@
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
@@ -9965,7 +9939,7 @@
     },
     "object-keys": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/object-keys/-/object-keys-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
       "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
     },
     "object.assign": {
@@ -10025,7 +9999,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -10072,7 +10046,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -10143,7 +10117,7 @@
       "dependencies": {
         "retry": {
           "version": "0.12.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/retry/-/retry-0.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
           "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
           "dev": true
         }
@@ -10182,12 +10156,12 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
@@ -10217,7 +10191,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -10225,7 +10199,7 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
@@ -10240,7 +10214,7 @@
     },
     "pkg-conf": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/pkg-conf/-/pkg-conf-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
       "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
       "dev": true,
       "requires": {
@@ -10250,7 +10224,7 @@
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -10259,7 +10233,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
@@ -10278,7 +10252,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
@@ -10287,13 +10261,13 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
@@ -10301,7 +10275,7 @@
     },
     "pkg-dir": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
@@ -10310,7 +10284,7 @@
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -10319,7 +10293,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/locate-path/-/locate-path-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
@@ -10338,7 +10312,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/p-locate/-/p-locate-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
@@ -10347,13 +10321,13 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/p-try/-/p-try-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
@@ -10473,7 +10447,7 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
@@ -10566,7 +10540,7 @@
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/q/-/q-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
@@ -10576,9 +10550,9 @@
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
     },
     "query-string": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz",
-      "integrity": "sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==",
+      "version": "6.13.7",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.7.tgz",
+      "integrity": "sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",
@@ -10694,7 +10668,7 @@
     },
     "redeyed": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/redeyed/-/redeyed-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
       "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
       "dev": true,
       "requires": {
@@ -10787,7 +10761,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -10822,7 +10796,7 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
@@ -10896,7 +10870,7 @@
     },
     "rimraf": {
       "version": "2.4.5",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/rimraf/-/rimraf-2.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
       "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
       "optional": true,
       "requires": {
@@ -11054,7 +11028,7 @@
     },
     "semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/semver-compare/-/semver-compare-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
@@ -11075,7 +11049,7 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "sharp": {
@@ -11103,7 +11077,7 @@
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
@@ -11112,7 +11086,7 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
@@ -11173,13 +11147,13 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "figures": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/figures/-/figures-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
@@ -11188,7 +11162,7 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
@@ -11287,13 +11261,13 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         }
@@ -11306,13 +11280,13 @@
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "spawn-error-forwarder": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
       "integrity": "sha1-Gv2Uc46ZmwNG17n8NzvlXgdXcCk=",
       "dev": true
     },
@@ -11382,7 +11356,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -11419,7 +11393,7 @@
     },
     "stream-combiner2": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
@@ -11519,7 +11493,7 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
@@ -11546,7 +11520,7 @@
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "stubs": {
@@ -11598,7 +11572,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -11725,13 +11699,13 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -11762,7 +11736,7 @@
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
@@ -11793,7 +11767,7 @@
     },
     "traverse": {
       "version": "0.6.6",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/traverse/-/traverse-0.6.6.tgz",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
@@ -11805,7 +11779,7 @@
     },
     "trim-off-newlines": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
     },
@@ -11848,19 +11822,20 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
     },
     "tus-js-client": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-2.1.1.tgz",
-      "integrity": "sha512-ILpgHlR0nfKxmlkXfrZ2z61upkHEXhADOGbGyvXSPjp7bn1NhU50p/Mu59q577Xirayr9vlW4tmoFqUrHKcWeQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-1.8.0.tgz",
+      "integrity": "sha512-qPX3TywqzxocTxUZtcS8X7Aik72SVMa0jKi4hWyfvRV+s9raVzzYGaP4MoJGaF0yOgm2+b6jXaVEHogxcJ8LGw==",
       "requires": {
         "buffer-from": "^0.1.1",
         "combine-errors": "^3.0.3",
+        "extend": "^3.0.2",
         "js-base64": "^2.4.9",
         "lodash.throttle": "^4.1.1",
         "proper-lockfile": "^2.0.1",
@@ -11877,16 +11852,26 @@
         "configstore": "^3.1.2",
         "crypto-rand": "0.0.2",
         "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -12008,7 +11993,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
@@ -12039,7 +12024,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -12058,12 +12043,12 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "which-pm-runs": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
     },
     "wide-align": {
@@ -12156,7 +12141,7 @@
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
@@ -12172,7 +12157,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
@@ -12224,7 +12209,7 @@
     },
     "xtend": {
       "version": "2.1.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/xtend/-/xtend-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
       "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "requires": {
         "object-keys": "~0.4.0"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "sideEffects": false,
   "dependencies": {
     "@reactioncommerce/api-utils": "^1.14.5",
-    "@reactioncommerce/file-collections": "~0.8.0",
-    "@reactioncommerce/file-collections-sa-gridfs": "~0.1.3",
+    "@reactioncommerce/file-collections": "~0.9.3",
+    "@reactioncommerce/file-collections-sa-gridfs": "~0.1.4",
     "@reactioncommerce/logger": "~1.1.2",
     "@reactioncommerce/random": "~1.0.2",
     "@reactioncommerce/reaction-error": "~1.0.1",


### PR DESCRIPTION
- Clean up package-lock via npm install to correctly
  use the public npm registry
- Part of reactioncommerce/reaction issue 6298


Impact: **minor**
Type: **bugfix**

## Issue

Uploading product images was failing.

## Solution

See https://github.com/reactioncommerce/reaction/issues/6298 for details. The fix will have to flow through several repos:

- reactioncommerce/file-collections (fixed in v0.9.3)
- reactioncommerce/file-collections-sa-gridfs (fixed in v0.1.4)
- reactioncommerce/api-plugin-files (this repo)
- reactioncommerce/docker-base (tangential)
- reactioncommerce/reaction


## Breaking changes


None known.



## Testing

- In reaction admin, create a product, save it, then upload an image. If it succeeds and the thumbnail is visible, this fix is verified.