### PR TITLE
chore: node version upgraded on ci for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: node:12.14.1
+      - image: node:14.18.1
 
     dependencies:
       pre:
@@ -20,7 +20,7 @@ jobs:
 
   deploy:
     docker:
-      - image: node:12.14.1
+      - image: node:14.18.1
 
     steps:
       - checkout
@@ -35,7 +35,7 @@ jobs:
 
   lint:
     docker:
-      - image: node:12.14.1
+      - image: node:14.18.1
 
     steps:
       - checkout
@@ -50,7 +50,7 @@ jobs:
 
   test-integration:
     docker:
-      - image: circleci/node:14.11.0-stretch
+      - image: circleci/node:14.18.1-stretch
       # Integration tests need MongoDB server running and accessible on port 27017
       - image: circleci/mongo:4.2.0
         command: mongod --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger


### PR DESCRIPTION
This PR updates the node version to be used on CircleCI. This makes sure that the integration tests don't fail on trunk.